### PR TITLE
Allow no push notifications without firebase configuration

### DIFF
--- a/apps/mediator/src/push-notifications/fcm/events/PushNotificationEvent.ts
+++ b/apps/mediator/src/push-notifications/fcm/events/PushNotificationEvent.ts
@@ -3,18 +3,24 @@ import { Logger } from '../../../logger'
 import { firebase } from '../firebase'
 
 export const sendFcmPushNotification = async (deviceToken: string, logger: Logger) => {
-  if (!config.get('agent:pushNotificationTitle')) {
-    throw new Error('Push notification title is missing')
+  if (firebase === undefined) {
+    logger.warn('Firebase is not initialized. Push notifications are disabled.')
+    return
   }
-  if (!config.get('agent:pushNotificationBody')) {
-    throw new Error('Push notification body is missing')
+
+  const title = config.get('agent:pushNotificationTitle')
+  const body = config.get('agent:pushNotificationBody')
+
+  if (!title || !body) {
+    throw new Error('Push notification title or body is missing')
   }
+  
   try {
     const response = await firebase.messaging().send({
       token: deviceToken,
       notification: {
-        title: config.get('agent:pushNotificationTitle'),
-        body: config.get('agent:pushNotificationBody'),
+        title,
+        body,
       },
     })
 

--- a/apps/mediator/src/push-notifications/fcm/firebase.ts
+++ b/apps/mediator/src/push-notifications/fcm/firebase.ts
@@ -1,11 +1,14 @@
 import admin from 'firebase-admin'
 import config from '../../config'
-export const firebase = admin.apps.length
-  ? admin.app()
-  : admin.initializeApp({
-      credential: admin.credential.cert({
-        projectId: config.get('agent:firebase:projectId'),
-        clientEmail: config.get('agent:firebase:clientEmail'),
-        privateKey: config.get('agent:firebase:privateKey'),
-      }),
-    })
+
+export const firebase: admin.app.App | undefined = !config.get('agent:usePushNotifications')
+  ? undefined
+  : admin.apps.length
+    ? admin.app()
+    : admin.initializeApp({
+        credential: admin.credential.cert({
+          projectId: config.get('agent:firebase:projectId'),
+          clientEmail: config.get('agent:firebase:clientEmail'),
+          privateKey: config.get('agent:firebase:privateKey')?.replace(/\\n/g, '\n'),
+        }),
+      });


### PR DESCRIPTION
When the firebase push notification stuff was added recently it prevented starting up an agent without push notifications enabled.  This was because it expected a firebase configuration even when USE_PUSH_NOTIFICATIONS was set to false or undefined. '