### PR TITLE
Fix/postgres pickup

### DIFF
--- a/apps/mediator/src/config.ts
+++ b/apps/mediator/src/config.ts
@@ -34,7 +34,7 @@ nconf.overrides({
       ? process.env.AGENT_ENDPOINTS.split(',')
       : [`http://localhost:${agentPort}`, `ws://localhost:${agentPort}`],
     name: process.env.AGENT_NAME ?? 'My Mediator',
-    invitationUrl: process.env.INVITATION_URL ?? `http://localhost:${agentPort}`,
+    invitationUrl: process.env.INVITATION_URL,
     logLevel: process.env.LOG_LEVEL ?? LogLevel.debug,
     usePushNotifications: process.env.USE_PUSH_NOTIFICATIONS === 'true',
     notificationWebhookUrl: process.env.NOTIFICATION_WEBHOOK_URL,

--- a/packages/message-pickup-repository-pg/src/PostgresMessagePickupRepository.ts
+++ b/packages/message-pickup-repository-pg/src/PostgresMessagePickupRepository.ts
@@ -172,7 +172,7 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
 
         return result.rows.map((message) => ({
           id: message.id,
-          encryptedMessage: message.encryptedmessage,
+          encryptedMessage: message.encrypted_message,
           state: message.state,
         }))
       }
@@ -189,7 +189,7 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
         ORDER BY created_at 
         LIMIT $3
       )
-      RETURNING id, encryptedmessage, state;
+      RETURNING id, encrypted_message, state;
     `
       const params = [connectionId, recipientDid, limit ?? 0]
       const result = await this.messagesCollection?.query(query, params)
@@ -204,7 +204,7 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
       // Return the messages as QueuedMessage objects
       return result.rows.map((message) => ({
         id: message.id,
-        encryptedMessage: message.encryptedmessage,
+        encryptedMessage: message.encrypted_message,
         state: 'sending',
       }))
     } catch (error) {
@@ -296,7 +296,7 @@ export class PostgresMessagePickupRepository implements MessagePickupRepository 
           id: messageRecord.id,
           connectionId,
           recipientDids,
-          encryptedMessage: messageRecord.encryptedmessage,
+          encryptedMessage: messageRecord.encrypted_message,
           receivedAt: messageRecord.created_at,
           state,
         },


### PR DESCRIPTION
The postgres pickup must have changed the column name for encrypted message at some point. Having it as `encryptedmessage` created an error in the `takeFromQueue` and `addMessage` functions. 

Also remove an unneeded default in the config file that messes up the invitation url when not set.