### PR TITLE
Load pickup repository via configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,7 @@ FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----...-----END PRIVATE KEY-----"
 # Wallet
 WALLET_KEY=a67d8724cb01c7c0b5d92f01fb052885
 WALLET_NAME=mediator-dev # Will be database name.
+
+PICKUP_TYPE=postgres
+PICKUP_STRATEGY=QueueOnly
+PICKUP_SETTINGS='{"useBaseConnection": true}'

--- a/apps/mediator/Dockerfile
+++ b/apps/mediator/Dockerfile
@@ -34,4 +34,4 @@ RUN addgroup --system --gid 1001 agent && \
 
 USER agent
 
-ENTRYPOINT [ "node", "build/index.js" ]
+ENTRYPOINT [ "node", "./build/apps/mediator/src/index.js" ]

--- a/apps/mediator/src/config.ts
+++ b/apps/mediator/src/config.ts
@@ -1,5 +1,6 @@
 import path from 'node:path'
 import { LogLevel } from '@credo-ts/core'
+import { MessageForwardingStrategy } from '@credo-ts/core/build/modules/routing/MessageForwardingStrategy'
 import dotenv from 'dotenv'
 import nconf from 'nconf'
 
@@ -44,6 +45,11 @@ nconf.overrides({
       projectId: process.env.FIREBASE_PROJECT_ID,
       clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
       privateKey: process.env.FIREBASE_PRIVATE_KEY,
+    },
+    pickup: {
+      type: process.env.PICKUP_TYPE?.toString().toLowerCase(),
+      strategy: process.env.PICKUP_STRATEGY ?? MessageForwardingStrategy.DirectDelivery,
+      settings: process.env.PICKUP_SETTINGS ?? JSON.stringify({}),
     },
   },
   wallet: {

--- a/apps/mediator/src/pickup/loader.ts
+++ b/apps/mediator/src/pickup/loader.ts
@@ -1,0 +1,40 @@
+import { MessagePickupRepository } from '@credo-ts/core'
+import { MessageForwardingStrategy } from '@credo-ts/core/build/modules/routing/MessageForwardingStrategy'
+import config from '../config'
+import { Logger } from '../logger'
+import { PickupType } from './type'
+
+const logger = new Logger(config.get('agent:logLevel'))
+
+type PickupConfig = {
+  useBaseConnection?: boolean
+  postgresHost?: string
+  postgresUser?: string
+  postgresPassword?: string
+  postgresDatabaseName?: string
+}
+
+export abstract class PickupLoader {
+  constructor(public readonly pickupConfig: PickupConfig) {}
+  abstract load(): Promise<MessagePickupRepository | undefined>
+}
+
+export const loadPickup = async (type: PickupType, strategy: MessageForwardingStrategy) => {
+  if (!Object.values(MessageForwardingStrategy).includes(strategy as MessageForwardingStrategy)) {
+    throw new Error(
+      `Invalid pickup forwarding strategy: ${strategy}, must be one of ${Object.values(MessageForwardingStrategy).join(', ')}`
+    )
+  }
+
+  logger.info(`Loading pickup with forwarding strategy: ${strategy}`)
+
+  const normalizedType = type.toLowerCase()
+  switch (normalizedType) {
+    case PickupType.Postgres.toLowerCase(): {
+      const { PostgresPickupLoader } = await import('./postgresLoader')
+      return await new PostgresPickupLoader().load()
+    }
+    default:
+      throw new Error(`Unsupported pickup type: ${type}, must be one of ${Object.values(PickupType).join(', ')}`)
+  }
+}

--- a/apps/mediator/src/pickup/postgresLoader.ts
+++ b/apps/mediator/src/pickup/postgresLoader.ts
@@ -1,0 +1,57 @@
+import { PostgresMessagePickupRepository } from '../../../../packages/message-pickup-repository-pg/src/PostgresMessagePickupRepository'
+import config from '../config'
+import { askarPostgresConfig } from '../database'
+import { Logger } from '../logger'
+import { PickupLoader } from './loader'
+
+const logger = new Logger(config.get('agent:logLevel'))
+
+type DbConfig = {
+  host: string
+  user: string
+  password: string
+  databaseName?: string
+}
+export class PostgresPickupLoader extends PickupLoader {
+  constructor() {
+    super(JSON.parse(config.get('agent:pickup').settings))
+  }
+
+  getDatabaseConfig(): DbConfig {
+    if (this.pickupConfig.useBaseConnection) {
+      const storageConfig = config.get('db:host') ? askarPostgresConfig : undefined
+      if (!storageConfig) {
+        throw new Error(`Agent is configured to use base connection, but agent isn't using postgres.`)
+      }
+      return {
+        host: storageConfig.config.host,
+        user: config.get('db:user'),
+        password: config.get('db:password'),
+        databaseName: this.pickupConfig.postgresDatabaseName || '',
+      }
+    }
+    if (!this.pickupConfig.postgresHost || !this.pickupConfig.postgresUser || !this.pickupConfig.postgresPassword) {
+      throw new Error(
+        'Postgres pickup configuration is incomplete. Please provide postgresHost, postgresUser, and postgresPassword.'
+      )
+    }
+    return {
+      host: this.pickupConfig.postgresHost,
+      user: this.pickupConfig.postgresUser,
+      password: this.pickupConfig.postgresPassword,
+      databaseName: this.pickupConfig.postgresDatabaseName || '',
+    }
+  }
+
+  async load(): Promise<PostgresMessagePickupRepository> {
+    logger.info('Loading Postgres message pickup repository...')
+    const databaseConfig = this.getDatabaseConfig()
+    return new PostgresMessagePickupRepository({
+      postgresHost: databaseConfig.host,
+      postgresUser: databaseConfig.user,
+      postgresPassword: databaseConfig.password,
+      postgresDatabaseName: databaseConfig.databaseName,
+      logger: logger,
+    })
+  }
+}

--- a/apps/mediator/src/pickup/tests/loader.test.ts
+++ b/apps/mediator/src/pickup/tests/loader.test.ts
@@ -1,0 +1,64 @@
+import { MessagePickupRepository } from '@credo-ts/core'
+import { MessageForwardingStrategy } from '@credo-ts/core/build/modules/routing/MessageForwardingStrategy'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { PickupLoader, loadPickup } from '../loader'
+import { PickupType } from '../type'
+
+vi.mock('../../config')
+vi.mock('../../logger', () => ({
+  Logger: vi.fn().mockImplementation(() => ({
+    info: vi.fn(),
+  })),
+}))
+
+// Mock PostgresPickupLoader
+vi.mock('../postgresLoader', () => {
+  return {
+    PostgresPickupLoader: vi.fn().mockImplementation(() => ({
+      load: vi.fn().mockReturnValueOnce({} as MessagePickupRepository),
+    })),
+  }
+})
+
+describe('loadPickup', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+  it('loads PostgresPickupLoader for valid type and strategy', async () => {
+    await loadPickup(PickupType.Postgres, MessageForwardingStrategy.DirectDelivery)
+
+    const { PostgresPickupLoader } = await import('../postgresLoader')
+    expect(PostgresPickupLoader).toHaveBeenCalledTimes(1)
+  })
+
+  it('throws error for unsupported pickup type', async () => {
+    await expect(loadPickup('unknown-type' as PickupType, MessageForwardingStrategy.DirectDelivery)).rejects.toThrow(
+      /Unsupported pickup type/
+    )
+  })
+
+  it('throws error for invalid forwarding strategy', async () => {
+    await expect(loadPickup(PickupType.Postgres, 'invalid-strategy' as MessageForwardingStrategy)).rejects.toThrow(
+      /Invalid pickup forwarding strategy/
+    )
+  })
+
+  it('is case insensitive when matching pickup type', async () => {
+    await loadPickup('POSTGRES' as PickupType, MessageForwardingStrategy.DirectDelivery)
+    const { PostgresPickupLoader } = await import('../postgresLoader')
+    expect(PostgresPickupLoader).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('PickupLoader abstract class', () => {
+  it('can be extended with a custom loader', async () => {
+    class DummyLoader extends PickupLoader {
+      async load() {
+        return undefined
+      }
+    }
+
+    const loader = new DummyLoader({ postgresHost: 'host' })
+    expect(loader.pickupConfig.postgresHost).toBe('host')
+  })
+})

--- a/apps/mediator/src/pickup/tests/postgresLoader.test.ts
+++ b/apps/mediator/src/pickup/tests/postgresLoader.test.ts
@@ -1,0 +1,142 @@
+import { Mock, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PostgresMessagePickupRepository } from '../../../../../packages/message-pickup-repository-pg/src/PostgresMessagePickupRepository'
+import config from '../../config'
+import { PostgresPickupLoader } from '../postgresLoader'
+
+vi.mock('../../config')
+vi.mock('../../database', () => ({
+  askarPostgresConfig: {
+    config: {
+      host: 'base-postgres-host',
+    },
+  },
+}))
+vi.mock('../../../../../packages/message-pickup-repository-pg/src/PostgresMessagePickupRepository')
+
+describe('PostgresPickupLoader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should return base DB config when useBaseConnection is true', () => {
+    ;(config.get as Mock).mockImplementation((...args: any[]) => {
+      const mockValues: Record<string, any> = {
+        'agent:pickup': {
+          settings: JSON.stringify({ useBaseConnection: true }),
+        },
+        'db:host': 'base-postgres-host',
+        'db:user': 'base-user',
+        'db:password': 'base-pass',
+        'db:databaseName': 'base-db',
+        'agent:logLevel': 'info',
+      }
+      return mockValues[args[0]]
+    })
+
+    const loader = new PostgresPickupLoader()
+    const configResult = loader.getDatabaseConfig()
+
+    expect(configResult).toEqual({
+      host: 'base-postgres-host',
+      user: 'base-user',
+      password: 'base-pass',
+      databaseName: 'base-db',
+    })
+  })
+
+  it('should throw if useBaseConnection is true but not using postgres', () => {
+    ;(config.get as Mock).mockImplementation((...args: any[]) => {
+      const mockValues: Record<string, any> = {
+        'agent:pickup': {
+          settings: JSON.stringify({ useBaseConnection: true }),
+        },
+        'db:host': undefined,
+        'agent:logLevel': 'info',
+      }
+      return mockValues[args[0]]
+    })
+
+    const loader = new PostgresPickupLoader()
+    expect(() => loader.getDatabaseConfig()).toThrow(
+      `Agent is configured to use base connection, but agent isn't using postgres.`
+    )
+  })
+
+  it('should return pickup config when useBaseConnection is false', () => {
+    ;(config.get as Mock).mockImplementation((...args: any[]) => {
+      const mockValues: Record<string, any> = {
+        'agent:pickup': {
+          settings: JSON.stringify({
+            useBaseConnection: false,
+            postgresHost: 'custom-host',
+            postgresUser: 'custom-user',
+            postgresPassword: 'custom-pass',
+            postgresDatabaseName: 'custom-db',
+          }),
+        },
+        'agent:logLevel': 'info',
+      }
+      return mockValues[args[0]]
+    })
+
+    const loader = new PostgresPickupLoader()
+    const configResult = loader.getDatabaseConfig()
+
+    expect(configResult).toEqual({
+      host: 'custom-host',
+      user: 'custom-user',
+      password: 'custom-pass',
+      databaseName: 'custom-db',
+    })
+  })
+
+  it('should throw if required pickup config is missing', () => {
+    ;(config.get as Mock).mockImplementation((...args: any[]) => {
+      const mockValues: Record<string, any> = {
+        'agent:pickup': {
+          settings: JSON.stringify({
+            useBaseConnection: false,
+          }),
+        },
+        'agent:logLevel': 'info',
+      }
+      return mockValues[args[0]]
+    })
+
+    const loader = new PostgresPickupLoader()
+    expect(() => loader.getDatabaseConfig()).toThrow(
+      'Postgres pickup configuration is incomplete. Please provide postgresHost, postgresUser, and postgresPassword.'
+    )
+  })
+
+  it('should call PostgresMessagePickupRepository with correct config in load()', async () => {
+    ;(config.get as Mock).mockImplementation((...args: any[]) => {
+      const mockValues: Record<string, any> = {
+        'agent:pickup': {
+          settings: JSON.stringify({
+            useBaseConnection: false,
+            postgresHost: 'host',
+            postgresUser: 'user',
+            postgresPassword: 'pass',
+            postgresDatabaseName: 'db',
+          }),
+        },
+        'agent:logLevel': 'info',
+      }
+      return mockValues[args[0]]
+    })
+
+    const loader = new PostgresPickupLoader()
+    await loader.load()
+
+    expect(PostgresMessagePickupRepository).toHaveBeenCalledWith(
+      expect.objectContaining({
+        postgresHost: 'host',
+        postgresUser: 'user',
+        postgresPassword: 'pass',
+        postgresDatabaseName: 'db',
+        logger: expect.anything(),
+      })
+    )
+  })
+})

--- a/apps/mediator/src/pickup/type.ts
+++ b/apps/mediator/src/pickup/type.ts
@@ -1,0 +1,4 @@
+export enum PickupType {
+  Postgres = 'Postgres',
+  DynamoDB = 'DynamoDB',
+}

--- a/apps/mediator/tsconfig.build.json
+++ b/apps/mediator/tsconfig.build.json
@@ -4,5 +4,6 @@
   "compilerOptions": {
     "outDir": "./build",
     "types": ["node"]
-  }
+  },
+  "exclude": ["**/*.test.ts", "tests"]
 }

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,8 @@
 {
   "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
   "files": {
-    "maxSize": 10000000
+    "maxSize": 10000000,
+    "ignore": ["**/*.test.ts"]
   },
   "formatter": {
     "lineWidth": 120,

--- a/charts/mediator/values.yaml
+++ b/charts/mediator/values.yaml
@@ -163,6 +163,12 @@ environment:
       secretKeyRef:
         name: mediator-credo-db
         key: postgres-password
+  - name: PICKUP_TYPE
+    value: '' # The default is 'DirectDelivery', it can be also be 'QueueOnly' or 'QueueAndLiveModeDelivery'
+  - name: PICKUP_STRATEGY
+    value: direct-delivery
+  - name: PICKUP_SETTINGS
+    value: '{}'
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 ## @param livenessProbe [object] Liveness probe configuration

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1865,6 +1865,7 @@ packages:
 
   '@sphereon/kmp-mdl-mdoc@0.2.0-SNAPSHOT.22':
     resolution: {integrity: sha512-uAZZExVy+ug9JLircejWa5eLtAZ7bnBP6xb7DO2+86LRsHNLh2k2jMWJYxp+iWtGHTsh6RYsZl14ScQLvjiQ/A==}
+    bundledDependencies: []
 
   '@sphereon/pex-models@2.3.2':
     resolution: {integrity: sha512-foFxfLkRwcn/MOp/eht46Q7wsvpQGlO7aowowIIb5Tz9u97kYZ2kz6K2h2ODxWuv5CRA7Q0MY8XUBGE2lfOhOQ==}
@@ -4601,6 +4602,11 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  semver@7.7.2:
+    resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   send@0.19.0:
     resolution: {integrity: sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==}
     engines: {node: '>= 0.8.0'}
@@ -6900,7 +6906,7 @@ snapshots:
       resolve: 1.22.10
       resolve-from: 5.0.0
       resolve.exports: 2.0.3
-      semver: 7.7.1
+      semver: 7.7.2
       send: 0.19.1
       slugify: 1.6.6
       source-map-support: 0.5.21
@@ -6935,7 +6941,7 @@ snapshots:
       getenv: 1.0.0
       glob: 10.4.5
       resolve-from: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       slash: 3.0.0
       slugify: 1.6.6
       xcode: 3.0.1
@@ -6959,7 +6965,7 @@ snapshots:
       require-from-string: 2.0.2
       resolve-from: 5.0.0
       resolve-workspace-root: 2.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       slugify: 1.6.6
       sucrase: 3.35.0
     transitivePeerDependencies:
@@ -6997,7 +7003,7 @@ snapshots:
       minimatch: 9.0.5
       p-limit: 3.1.0
       resolve-from: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
     optional: true
@@ -7010,7 +7016,7 @@ snapshots:
       jimp-compact: 0.16.1
       parse-png: 2.1.0
       resolve-from: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       temp-dir: 2.0.0
       unique-string: 2.0.0
     optional: true
@@ -7079,7 +7085,7 @@ snapshots:
       '@react-native/normalize-colors': 0.79.2
       debug: 4.4.0
       resolve-from: 5.0.0
-      semver: 7.7.1
+      semver: 7.7.2
       xml2js: 0.6.0
     transitivePeerDependencies:
       - supports-color
@@ -7276,7 +7282,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.17
+      '@types/node': 20.17.46
       jest-mock: 29.7.0
     optional: true
 
@@ -7284,7 +7290,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.15.17
+      '@types/node': 20.17.46
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -7321,7 +7327,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.15.17
+      '@types/node': 20.17.46
       '@types/yargs': 17.0.33
       chalk: 4.1.2
     optional: true
@@ -7678,7 +7684,7 @@ snapshots:
       metro: 0.82.3
       metro-config: 0.82.3
       metro-core: 0.82.3
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -8233,7 +8239,7 @@ snapshots:
 
   '@types/graceful-fs@4.1.9':
     dependencies:
-      '@types/node': 22.15.17
+      '@types/node': 20.17.46
     optional: true
 
   '@types/http-errors@2.0.4': {}
@@ -8952,7 +8958,7 @@ snapshots:
 
   chrome-launcher@0.15.2:
     dependencies:
-      '@types/node': 22.15.17
+      '@types/node': 20.17.46
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -8964,7 +8970,7 @@ snapshots:
 
   chromium-edge-launcher@0.2.0:
     dependencies:
-      '@types/node': 22.15.17
+      '@types/node': 20.17.46
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 1.4.2
@@ -10117,7 +10123,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.15.17
+      '@types/node': 20.17.46
       jest-mock: 29.7.0
       jest-util: 29.7.0
     optional: true
@@ -10129,7 +10135,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@types/graceful-fs': 4.1.9
-      '@types/node': 22.15.17
+      '@types/node': 20.17.46
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -10158,7 +10164,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.15.17
+      '@types/node': 20.17.46
       jest-util: 29.7.0
     optional: true
 
@@ -10168,7 +10174,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.15.17
+      '@types/node': 20.17.46
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -10193,7 +10199,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.15.17
+      '@types/node': 20.17.46
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -10886,7 +10892,7 @@ snapshots:
     dependencies:
       hosted-git-info: 7.0.2
       proc-log: 4.2.0
-      semver: 7.7.1
+      semver: 7.7.2
       validate-npm-package-name: 5.0.1
     optional: true
 
@@ -11343,7 +11349,7 @@ snapshots:
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.11
       scheduler: 0.25.0
-      semver: 7.7.1
+      semver: 7.7.2
       stacktrace-parser: 0.1.11
       whatwg-fetch: 3.6.20
       ws: 6.2.3
@@ -11540,6 +11546,9 @@ snapshots:
   semver@6.3.1: {}
 
   semver@7.7.1: {}
+
+  semver@7.7.2:
+    optional: true
 
   send@0.19.0:
     dependencies:


### PR DESCRIPTION
This pull request allows the mediator to load a pickup repository through environment variables and config values. It only currently allows the postgres pickup repository to be loaded but adding a loader for the dynamodb pickup should be straight forward. 