### PR TITLE
feat: Install jemalloc and allow configuration/loading with env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ The `POSTGRES_` variables won't be used in development mode (`NODE_ENV=developme
 | `FIREBASE_CLIENT_EMAIL`    | (OPTIONAL) Firebase client email generated when setting up Firebase Cloud Messaging project, required if sending push notifications via Firebase Cloud Messaging.                                                                                                                 |
 | `FIREBASE_PRIVATE_KEY`     | (OPTIONAL) Private key generated when setting up Firebase Cloud Messaging project, required if sending push notifications via Firebase Cloud Messaging.                                                                                                                           |
 | `NOTIFICATION_WEBHOOK_URL` | (OPTIONAL) A url used for sending notifications to                                                                                                                                                                                                                                |
+| `NODE_OPTIONS`          | Options to pass to Node.js runtime. We recommend setting this to `--max-old-space-size=512` to limit the memory usage of the agent.                                                                                                                                                |
+| `MALLOC_CONF`          | Options to pass to the memory allocator. We recommend setting this to `background_thread:true,metadata_thp:auto` to improve performance.                                                                                                                                                |
+| `LD_PRELOAD`          | Preload the jemalloc memory allocator. We recommend setting this to `/usr/lib/x86_64-linux-gnu/libjemalloc.so.2` to improve performance.                                                                                                                                                |
 
 ## Postgres Database
 

--- a/apps/mediator/Dockerfile
+++ b/apps/mediator/Dockerfile
@@ -21,7 +21,14 @@ FROM base AS final
 
 WORKDIR /app
 
-# Copy build
+# Install jemalloc, allows loading a different memory allocator
+# to help with memory fragmentation issues in long running node processes
+# See https://jemalloc.net/
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libjemalloc2 \
+ && rm -rf /var/lib/apt/lists/*
+
+# Copy build artifacts
 COPY --from=build /build/node_modules /app/node_modules
 COPY --from=build /build/apps/mediator/build /app/build
 COPY --from=build /build/apps/mediator/package.json /app

--- a/charts/mediator/values.yaml
+++ b/charts/mediator/values.yaml
@@ -169,6 +169,12 @@ environment:
     value: DirectDelivery # The default is 'DirectDelivery', it can be also be 'QueueOnly' or 'QueueAndLiveModeDelivery'
   - name: PICKUP_SETTINGS
     value: '{}'
+  - name: NODE_OPTIONS
+    value: '' # This can be used to set node options like --max-old-space-size=240
+  - name: MALLOC_CONF
+    value: '' # This can be used to set memory allocation options for the container
+  - name: LD_PRELOAD
+    value: '' # This can be used to set a different memory allocator like jemalloc
 
 # This is to setup the liveness and readiness probes more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
 ## @param livenessProbe [object] Liveness probe configuration


### PR DESCRIPTION
When load testing the mediator and experiencing some non-optimal memory behavior, we tried a custom memory allocator `jemalloc` which had substantial improvements. 

This installs jemalloc in the docker container and then allows custom settings to load the allocator and set custom configurations for it. It also exposes NODE_OPTIONS for custom configuration based on the deployment.

Here is a chatGPT thread about jemalloc for some additional information on why we think this is a good idea. https://chatgpt.com/c/68d585ea-0e38-8321-93ab-2b5870086900