### PR TITLE
feat: Setup firebase sender for other pickup strategies

### DIFF
--- a/apps/mediator/src/agent.ts
+++ b/apps/mediator/src/agent.ts
@@ -24,8 +24,8 @@ import { askarPostgresConfig } from './database'
 import { Logger } from './logger'
 import { loadPickup } from './pickup/loader'
 import { PushNotificationsFcmModule } from './push-notifications/fcm'
-import { StorageMessageQueueModule } from './storage/StorageMessageQueueModule'
 import { initializePushNotificationSender } from './push-notifications/fcm/firebase'
+import { StorageMessageQueueModule } from './storage/StorageMessageQueueModule'
 
 function createModules(messagePickupRepository?: MessagePickupRepository) {
   type Modules = {

--- a/apps/mediator/src/agent.ts
+++ b/apps/mediator/src/agent.ts
@@ -25,6 +25,7 @@ import { Logger } from './logger'
 import { loadPickup } from './pickup/loader'
 import { PushNotificationsFcmModule } from './push-notifications/fcm'
 import { StorageMessageQueueModule } from './storage/StorageMessageQueueModule'
+import { initializePushNotificationSender } from './push-notifications/fcm/firebase'
 
 function createModules(messagePickupRepository?: MessagePickupRepository) {
   type Modules = {
@@ -173,6 +174,8 @@ export async function createAgent() {
       socketServer.emit('connection', socket, request)
     })
   })
+
+  await initializePushNotificationSender(agent)
 
   return agent
 }

--- a/apps/mediator/src/push-notifications/fcm/firebase.ts
+++ b/apps/mediator/src/push-notifications/fcm/firebase.ts
@@ -21,7 +21,7 @@ export const firebase: admin.app.App | undefined = !config.get('agent:usePushNot
 // DirectDelivery sender is built into the storage module and does not need initialization here
 export async function initializePushNotificationSender(agent: Agent) {
   if (!config.get('agent:usePushNotifications')) return
-  
+
   // For live mode and postgres pickup type, listen for queued messages and send push notifications
   if (
     config.get('agent:pickup:strategy') === MessageForwardingStrategy.QueueAndLiveModeDelivery &&

--- a/apps/mediator/src/push-notifications/fcm/firebase.ts
+++ b/apps/mediator/src/push-notifications/fcm/firebase.ts
@@ -1,35 +1,47 @@
-import admin from 'firebase-admin'
-import config from '../../config'
 import { Agent } from '@credo-ts/core'
 import { MessageForwardingStrategy } from '@credo-ts/core/build/modules/routing/MessageForwardingStrategy'
+import admin from 'firebase-admin'
+import config from '../../config'
+import { Logger } from '../../logger'
 import { PickupType } from '../../pickup/type'
 import { sendFcmPushNotification } from './events/PushNotificationEvent'
-import { Logger } from '../../logger'
 
 export const firebase: admin.app.App | undefined = !config.get('agent:usePushNotifications')
   ? undefined
   : admin.apps.length
     ? admin.app()
     : admin.initializeApp({
-      credential: admin.credential.cert({
-        projectId: config.get('agent:firebase:projectId'),
-        clientEmail: config.get('agent:firebase:clientEmail'),
-        privateKey: config.get('agent:firebase:privateKey')?.replace(/\\n/g, '\n'),
-      }),
-    })
+        credential: admin.credential.cert({
+          projectId: config.get('agent:firebase:projectId'),
+          clientEmail: config.get('agent:firebase:clientEmail'),
+          privateKey: config.get('agent:firebase:privateKey')?.replace(/\\n/g, '\n'),
+        }),
+      })
 
 // DirectDelivery sender is built into the storage module and does not need initialization here
 export async function initializePushNotificationSender(agent: Agent) {
-  // For live mode and postgres pickup type, listen for queued messages and send push notifications 
-  if (config.get("agent:pickup:strategy") === MessageForwardingStrategy.QueueAndLiveModeDelivery && config.get("agent:pickup:type") === PickupType.Postgres.toLowerCase()) {
-    const { MessageQueuedEventType } = await import('../../../../../packages/message-pickup-repository-pg/src/interfaces')
-    type MessageQueuedEvent = import('../../../../../packages/message-pickup-repository-pg/src/interfaces').MessageQueuedEvent
+  // For live mode and postgres pickup type, listen for queued messages and send push notifications
+  if (
+    config.get('agent:pickup:strategy') === MessageForwardingStrategy.QueueAndLiveModeDelivery &&
+    config.get('agent:pickup:type') === PickupType.Postgres.toLowerCase()
+  ) {
+    const { MessageQueuedEventType } = await import(
+      '../../../../../packages/message-pickup-repository-pg/src/interfaces'
+    )
+    type MessageQueuedEvent = import(
+      '../../../../../packages/message-pickup-repository-pg/src/interfaces'
+    ).MessageQueuedEvent
 
-    agent.config.logger.info('Initializing push notification sender on queued messages for postgres pickup type and queue and live mode delivery strategy')
+    agent.config.logger.info(
+      'Initializing push notification sender on queued messages for postgres pickup type and queue and live mode delivery strategy'
+    )
     agent.events.on(MessageQueuedEventType, async (data) => {
       const { message } = data.payload as unknown as MessageQueuedEvent
-      const pushNotificationRecord = await agent.modules.pushNotificationsFcm.getPushNotificationRecordByConnectionId(message.connectionId)
-      if (pushNotificationRecord.deviceToken) sendFcmPushNotification(pushNotificationRecord.deviceToken, agent.config.logger as Logger)
+      const pushNotificationRecord = await agent.modules.pushNotificationsFcm.getPushNotificationRecordByConnectionId(
+        message.connectionId
+      )
+      if (pushNotificationRecord.deviceToken)
+        sendFcmPushNotification(pushNotificationRecord.deviceToken, agent.config.logger as Logger)
     })
   }
 }

--- a/apps/mediator/src/push-notifications/fcm/firebase.ts
+++ b/apps/mediator/src/push-notifications/fcm/firebase.ts
@@ -1,14 +1,35 @@
 import admin from 'firebase-admin'
 import config from '../../config'
+import { Agent } from '@credo-ts/core'
+import { MessageForwardingStrategy } from '@credo-ts/core/build/modules/routing/MessageForwardingStrategy'
+import { PickupType } from '../../pickup/type'
+import { sendFcmPushNotification } from './events/PushNotificationEvent'
+import { Logger } from '../../logger'
 
 export const firebase: admin.app.App | undefined = !config.get('agent:usePushNotifications')
   ? undefined
   : admin.apps.length
     ? admin.app()
     : admin.initializeApp({
-        credential: admin.credential.cert({
-          projectId: config.get('agent:firebase:projectId'),
-          clientEmail: config.get('agent:firebase:clientEmail'),
-          privateKey: config.get('agent:firebase:privateKey')?.replace(/\\n/g, '\n'),
-        }),
-      })
+      credential: admin.credential.cert({
+        projectId: config.get('agent:firebase:projectId'),
+        clientEmail: config.get('agent:firebase:clientEmail'),
+        privateKey: config.get('agent:firebase:privateKey')?.replace(/\\n/g, '\n'),
+      }),
+    })
+
+// DirectDelivery sender is built into the storage module and does not need initialization here
+export async function initializePushNotificationSender(agent: Agent) {
+  // For live mode and postgres pickup type, listen for queued messages and send push notifications 
+  if (config.get("agent:pickup:strategy") === MessageForwardingStrategy.QueueAndLiveModeDelivery && config.get("agent:pickup:type") === PickupType.Postgres.toLowerCase()) {
+    const { MessageQueuedEventType } = await import('../../../../../packages/message-pickup-repository-pg/src/interfaces')
+    type MessageQueuedEvent = import('../../../../../packages/message-pickup-repository-pg/src/interfaces').MessageQueuedEvent
+
+    agent.config.logger.info('Initializing push notification sender on queued messages for postgres pickup type and queue and live mode delivery strategy')
+    agent.events.on(MessageQueuedEventType, async (data) => {
+      const { message } = data.payload as unknown as MessageQueuedEvent
+      const pushNotificationRecord = await agent.modules.pushNotificationsFcm.getPushNotificationRecordByConnectionId(message.connectionId)
+      if (pushNotificationRecord.deviceToken) sendFcmPushNotification(pushNotificationRecord.deviceToken, agent.config.logger as Logger)
+    })
+  }
+}

--- a/apps/mediator/src/push-notifications/fcm/firebase.ts
+++ b/apps/mediator/src/push-notifications/fcm/firebase.ts
@@ -20,6 +20,8 @@ export const firebase: admin.app.App | undefined = !config.get('agent:usePushNot
 
 // DirectDelivery sender is built into the storage module and does not need initialization here
 export async function initializePushNotificationSender(agent: Agent) {
+  if (!config.get('agent:usePushNotifications')) return
+  
   // For live mode and postgres pickup type, listen for queued messages and send push notifications
   if (
     config.get('agent:pickup:strategy') === MessageForwardingStrategy.QueueAndLiveModeDelivery &&


### PR DESCRIPTION
The method for sending a firebase push notification was built directly into the storage module for DirectDelivery strategy. However, when using another pickup strategy and repository type a custom sender needs to be setup. For postgres pickup it needs to send on a `MessageQueuedEvent`. This initialization method sets this up. Other pickup repository types and potential other push notification methods can be added in the future.  